### PR TITLE
Various improvement to CloudWatch logging for ECS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ module "alarm" {
 
   subscriptions = [
       {
+        protocol = "email"
+        endpoint = "admin@example.com"
+      },
+
+      {
         protocol = "sms"
         endpoint = "+18005551212"
       },
   ]
-
-  ecs_cluster = "foo"
 
   ecs_services = {
     "foo-daemon" = {
@@ -47,13 +50,13 @@ Argument Reference
 
 The following arguments are supported:
 
-* `ecs_cluster` – (Required) ECS cluster containing services for which alarms
+* `ecs_cluster` – (Optional) ECS cluster containing services for which alarms
 are created.
 
-* `ecs_services` – (Optional) Map of ECS services for which alarms are created; key is name of service and value is an object with the attributes `cpu` and `memory`.
+* `ecs_services` – (Optional) Map of ECS services for which metric alarms are created; key is name of service and value is an object with the attributes `cpu` and `memory`.
 Both attributes are numeric values.
 
-* `name` – (Required) Service name. This is used to form the name of alarm(s).
+* `name` – (Required) Service name. This is used to form the name of metric alarm(s).
 
 * `subscriptions` (Optional) A [subscriptions](#subscriptions) block. The
 `subscriptions` block is documented below.
@@ -63,20 +66,14 @@ Both attributes are numeric values.
 `subscriptions`
 ------------------
 
-A `subscription` block consists of a list containing one or more maps, each
-of which must contain the following keys:
-
-* `protocol` – (Required) The protocol to use. The fully-supported values
-for this are: `sqs`, `sms`, `lambda`, `application`.
+A `subscription` block consists of a list containing one or more maps, wherein each
+map must contain the following keys:
 
 * `endpoint` – (Required) The endpoint to send data to, the contents will
 vary with the protocol.
 
-**Note:** AWS supports additional `email` and `email-json` protocols that are
-not supported by Terraform because the authorization process does not generate
-an ARN until the target email address has been validated.
-However, subscriptions using the `email` and `email-json` protocols can be
-created in the AWS console.
+* `protocol` – (Required) The protocol to use. The fully-supported values
+for this are: `email`, `sqs`, `sms`, `lambda`, `application`.
 
 Additionally, `http` and `https` protocols are only partially supported by
 Terraform.
@@ -90,6 +87,8 @@ Attributes Reference
 
 The following attributes are exported:
 
-* `alarm_arn` – List consisting of ARNs of each alarm managed by the module.
+* `metric_alarms` – List consisting of ARNs of each CloudWatch metric alarm managed by the module.
 
-* `topic_arn` - ARN of the SNS alarm topic for this service.
+* `subscriptions` – List containing the subscriptions managed for the SNS topic. The format of each member of this list is `protocol:endpoint`.
+
+* `topic` - ARN of the SNS topic used for this service.

--- a/alarm_ecs.tf
+++ b/alarm_ecs.tf
@@ -63,6 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_services" {
     ServiceName = each.value.service
   }
 
-  alarm_actions = [aws_sns_topic.default.arn]
+  alarm_actions = [module.topic.topic_arns[0]]
+  ok_actions    = [module.topic.topic_arns[0]]
   tags          = merge(var.tags, { Name = each.value.alarm_name })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,13 @@
-output "alarm_arn" {
+output "metric_alarms" {
   value = [for alarm in aws_cloudwatch_metric_alarm.ecs_services : alarm.arn]
 }
 
-output "topic_arn" {
-  value = aws_sns_topic.default.arn
+output "subscriptions" {
+  value = [
+    for s in var.subscriptions : format("%s:%s", s.protocol, s.endpoint)
+  ]
+}
+
+output "topic" {
+  value = module.topic.topic_arns[0]
 }

--- a/sns.tf
+++ b/sns.tf
@@ -1,15 +1,29 @@
-resource "aws_sns_topic" "default" {
-  name = "${var.name}-alarm"
+module "topic" {
+  source = "github.com/techservicesillinois/terraform-aws-sns//modules/topic?ref=v3.1.1"
+
+  tags   = var.tags
+  topics = [format("%s-topic", var.name)]
 }
 
-#resource "aws_sns_topic" "ok" {
-# name = "${var.name}-ok"
-#}
+locals {
+  subscriptions = {
+    format("%s-topic", var.name) = [
+      for sub in var.subscriptions :
+      {
+        endpoint = sub.endpoint
+        protocol = sub.protocol
+      }
+    ]
+  }
+}
 
-resource "aws_sns_topic_subscription" "default" {
-  count = length(var.subscriptions)
+module "subscription" {
+  source = "github.com/techservicesillinois/terraform-aws-sns//modules/subscription?ref=v3.1.1"
 
-  topic_arn = aws_sns_topic.default.arn
-  protocol  = var.subscriptions[count.index].protocol
-  endpoint  = var.subscriptions[count.index].endpoint
+  # Explicit 'depends_on' is required because subscriptions module
+  # arguments are topic names instead of topic ARNs.
+  depends_on = [module.topic]
+
+  subscriptions = local.subscriptions
+  # NOTE: Tags are not supported by this resource.
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "ecs_cluster" {
   type        = string
   description = "ECS cluster containing services for which alarms are created"
+  default     = null
 }
 
 variable "ecs_services" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
*   Take advantage of reusable code by using new terraform-aws-sns module for notifications.

*   Fix misnamed resources. SNS topics were incorrectly referred to as alarms. An alarm is simply one of several notifications that can be published to a SNS topic.

*   Previous module version only published to the SNS topic when a CloudWatch metric went into alarm state. This version now also publishes publishes notification when the metric returns to OK state.

*   Revise outputs to make them more useful, renaming where it was possible to use more intuitive names.

*   Revise `README.md` file to reflect the above changes.